### PR TITLE
Importert de fulle Kodene fra kabal-api, så kodeverket er mest mulig likt. 

### DIFF
--- a/src/main/kotlin/no/nav/klage/dokument/api/input/JournalfoeringDataInput.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/api/input/JournalfoeringDataInput.kt
@@ -2,9 +2,11 @@ package no.nav.klage.dokument.api.input
 
 data class JournalfoeringDataInput(
     val sakenGjelder: PartIdInput,
-    val tema: String,
+    val tema: String?,
+    val temaId: String?,
     val sakFagsakId: String?,
     val sakFagsystem: String?,
+    val sakFagsystemId: String?,
     val kildeReferanse: String,
     val enhet: String,
     val behandlingstema: String,

--- a/src/main/kotlin/no/nav/klage/dokument/api/input/PartIdInput.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/api/input/PartIdInput.kt
@@ -1,3 +1,3 @@
 package no.nav.klage.dokument.api.input
 
-data class PartIdInput(val type: String, val value: String)
+data class PartIdInput(val type: String?, val partIdTypeId: String?, val value: String)

--- a/src/main/kotlin/no/nav/klage/dokument/api/mapper/DokumentEnhetInputMapper.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/api/mapper/DokumentEnhetInputMapper.kt
@@ -45,9 +45,10 @@ class DokumentEnhetInputMapper {
         try {
             JournalfoeringData(
                 sakenGjelder = mapPartIdInput(input.sakenGjelder),
-                tema = Tema.valueOf(input.tema),
+                tema = if (input.temaId != null) Tema.of(input.temaId) else Tema.valueOf(input.tema!!),
                 sakFagsakId = input.sakFagsakId,
-                sakFagsystem = input.sakFagsystem?.let { Fagsystem.valueOf(it) },
+                sakFagsystem = if (input.sakFagsystemId != null) Fagsystem.of(input.sakFagsystemId) else
+                    input.sakFagsystem?.let { Fagsystem.valueOf(it) },
                 kildeReferanse = input.kildeReferanse,
                 enhet = input.enhet,
                 behandlingstema = input.behandlingstema,
@@ -63,7 +64,8 @@ class DokumentEnhetInputMapper {
     private fun mapPartIdInput(partIdInput: PartIdInput) =
         try {
             PartId(
-                type = PartIdType.valueOf(partIdInput.type),
+                type = if (partIdInput.partIdTypeId != null) PartIdType.of(partIdInput.partIdTypeId)
+                else PartIdType.valueOf(partIdInput.type!!),
                 value = partIdInput.value
             )
         } catch (iae: IllegalArgumentException) {

--- a/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/Fagsystem.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/Fagsystem.kt
@@ -1,24 +1,36 @@
 package no.nav.klage.dokument.domain.kodeverk
 
-enum class Fagsystem {
-    FS36,
+enum class Fagsystem(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
+    FS36("1", "FS36", "Vedtaksløsning Foreldrepenger"),
 
     //MERK: FS39 er ikke lenger i bruk, og kan anses som utgått.
-    FS39,
-    AO01,
-    AO11,
-    BISYS,
-    FS38,
-    IT01,
-    K9,
-    OB36,
-    OEBS,
-    PP01,
-    UFM,
-    BA,
-    EF,
-    KONT,
-    SUPSTONAD,
-    OMSORGSPENGER,
-    MANUELL;
+    FS39("2", "FS39", "Saksbehandling for Folketrygdloven kapittel 9"),
+    AO01("3", "AO01", "Arena"),
+    AO11("4", "AO11", "Grisen"),
+    BISYS("5", "BISYS", "BISYS"),
+    FS38("6", "FS38", "Melosys"),
+    IT01("7", "IT01", "Infotrygd"),
+    K9("8", "K9", "Sykdom i familien"),
+    OB36("9", "OB36", "Utbetalingsmelding"),
+    OEBS("10", "OEBS", "OEBS"),
+    PP01("11", "PP01", "Pesys"),
+    UFM("12", "UFM", "Unntak fra medlemskap"),
+    BA("13", "BA", "Barnetrygd"),
+    EF("14", "EF", "Enslig forsørger"),
+    KONT("15", "KONT", "Kontantstøtte"),
+    SUPSTONAD("16", "SUPSTONAD", "Supplerende Stønad"),
+    OMSORGSPENGER("17", "OMSORGSPENGER", "Omsorgspenger"),
+    MANUELL("18", "MANUELL", "Manuell registrering av kvalitetsskjema");
+
+    companion object {
+        fun of(id: String): Fagsystem {
+            return values().firstOrNull { it.id == id }
+                ?: throw IllegalArgumentException("No Fagsystem with $id exists")
+        }
+
+        fun fromNavn(navn: String): Fagsystem {
+            return values().firstOrNull { it.navn == navn }
+                ?: throw IllegalArgumentException("No Fagsystem with $navn exists")
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/Kode.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/Kode.kt
@@ -1,0 +1,7 @@
+package no.nav.klage.dokument.domain.kodeverk
+
+interface Kode {
+    val id: String
+    val navn: String
+    val beskrivelse: String
+}

--- a/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/PartIdType.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/PartIdType.kt
@@ -1,6 +1,18 @@
 package no.nav.klage.dokument.domain.kodeverk
 
-enum class PartIdType {
-    PERSON,
-    VIRKSOMHET;
+enum class PartIdType(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
+    PERSON("PERSON", "Person", "Person"),
+    VIRKSOMHET("VIRKSOMHET", "Virksomhet", "Virksomhet");
+
+    override fun toString(): String {
+        return "PartIdType(id=$id, " +
+                "navn=$navn)"
+    }
+
+    companion object {
+        fun of(id: String): PartIdType {
+            return values().firstOrNull { it.id == id }
+                ?: throw IllegalArgumentException("No PartIdType with $id exists")
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/Tema.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/domain/kodeverk/Tema.kt
@@ -1,62 +1,81 @@
 package no.nav.klage.dokument.domain.kodeverk
 
-enum class Tema {
 
-    AAP,
-    AAR,
-    AGR,
-    BAR,
-    BID,
-    BIL,
-    DAG,
-    ENF,
-    ERS,
-    FAR,
-    FEI,
-    FOR,
-    FOS,
-    FRI,
-    FUL,
-    GEN,
-    GRA,
-    GRU,
-    HEL,
-    HJE,
-    IAR,
-    IND,
-    KON,
-    KTR,
-    MED,
-    MOB,
-    OMS,
-    OPA,
-    OPP,
-    PEN,
-    PER,
-    REH,
-    REK,
-    RPO,
-    RVE,
-    SAA,
-    SAK,
-    SAP,
-    SER,
-    SIK,
-    STO,
-    SUP,
-    SYK,
-    SYM,
-    TIL,
-    TRK,
-    TRY,
-    TSO,
-    TSR,
-    UFM,
-    UFO,
-    UKJ,
-    VEN,
-    YRA,
-    YRK,
-    GOS //Er ikke egentlig et tema, men returneres fra Axsys likevel
+enum class Tema(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
+
+    AAP("1", "AAP", "Arbeidsavklaringspenger"),
+    AAR("2", "AAR", "Aa-registeret"),
+    AGR("3", "AGR", "Ajourhold - Grunnopplysninger"),
+    BAR("4", "BAR", "Barnetrygd"),
+    BID("5", "BID", "Bidrag"),
+    BIL("6", "BIL", "Bil"),
+    DAG("7", "DAG", "Dagpenger"),
+    ENF("8", "ENF", "Enslig forsørger"),
+    ERS("9", "ERS", "Erstatning"),
+    FAR("10", "FAR", "Farskap"),
+    FEI("11", "FEI", "Feilutbetaling"),
+    FOR("12", "FOR", "Foreldre- og svangerskapspenger"),
+    FOS("13", "FOS", "Forsikring"),
+    FRI("14", "FRI", "Kompensasjon for selvstendig næringsdrivende/frilansere"),
+    FUL("15", "FUL", "Fullmakt"),
+    GEN("16", "GEN", "Generell"),
+    GRA("17", "GRA", "Gravferdsstønad"),
+    GRU("18", "GRU", "Grunn- og hjelpestønad"),
+    HEL("19", "HEL", "Helsetjenester og ortopediske hjelpemidler"),
+    HJE("20", "HJE", "Hjelpemidler"),
+    IAR("21", "IAR", "Inkluderende arbeidsliv"),
+    IND("22", "IND", "Tiltakspenger"),
+    KON("23", "KON", "Kontantstøtte"),
+    KTR("24", "KTR", "Kontroll"),
+    MED("25", "MED", "Medlemskap"),
+    MOB("26", "MOB", "Mobilitetsfremmende stønad"),
+    OMS("27", "OMS", "Omsorgspenger, pleiepenger og opplæringspenger"),
+    OPA("28", "OPA", "Oppfølging - Arbeidsgiver"),
+    OPP("29", "OPP", "Oppfølging"),
+    PEN("30", "PEN", "Pensjon"),
+    PER("31", "PER", "Permittering og masseoppsigelser"),
+    REH("32", "REH", "Rehabilitering"),
+    REK("33", "REK", "Rekruttering og stilling"),
+    RPO("34", "RPO", "Retting av personopplysninger"),
+    RVE("35", "RVE", "Rettferdsvederlag"),
+    SAA("36", "SAA", "Sanksjon - Arbeidsgiver"),
+    SAK("37", "SAK", "Saksomkostninger"),
+    SAP("38", "SAP", "Sanksjon - Person"),
+    SER("39", "SER", "Serviceklager"),
+    SIK("40", "SIK", "Sikkerhetstiltak"),
+    STO("41", "STO", "Regnskap/utbetaling"),
+    SUP("42", "SUP", "Supplerende stønad"),
+    SYK("43", "SYK", "Sykepenger"),
+    SYM("44", "SYM", "Sykmeldinger"),
+    TIL("45", "TIL", "Tiltak"),
+    TRK("46", "TRK", "Trekkhåndtering"),
+    TRY("47", "TRY", "Trygdeavgift"),
+    TSO("48", "TSO", "Tilleggsstønad"),
+    TSR("49", "TSR", "Tilleggsstønad arbeidssøkere"),
+    UFM("50", "UFM", "Unntak fra medlemskap"),
+    UFO("51", "UFO", "Uføretrygd"),
+    UKJ("52", "UKJ", "Ukjent"),
+    VEN("53", "VEN", "Ventelønn"),
+    YRA("54", "YRA", "Yrkesrettet attføring"),
+    YRK("55", "YRK", "Yrkesskade / Menerstatning"),
+    GOS("56", "GOS", "Gosys") //Er ikke egentlig et tema, men returneres fra Axsys likevel
     ;
+
+    override fun toString(): String {
+        return "Tema(id=$id, " +
+                "navn=$navn)"
+    }
+
+    companion object {
+        fun of(id: String): Tema {
+            return values().firstOrNull { it.id == id }
+                ?: throw IllegalArgumentException("No Tema with $id exists")
+        }
+
+        fun fromNavn(navn: String?): Tema {
+            return values().firstOrNull { it.navn == navn }
+                ?: throw IllegalArgumentException("No Tema with $navn exists")
+        }
+    }
 }
+

--- a/src/test/kotlin/no/nav/klage/dokument/api/controller/DokumentEnhetControllerTest.kt
+++ b/src/test/kotlin/no/nav/klage/dokument/api/controller/DokumentEnhetControllerTest.kt
@@ -5,10 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
 import io.mockk.every
-import no.nav.klage.dokument.api.input.BrevMottakerInput
-import no.nav.klage.dokument.api.input.DokumentEnhetInput
-import no.nav.klage.dokument.api.input.JournalfoeringDataInput
-import no.nav.klage.dokument.api.input.PartIdInput
+import no.nav.klage.dokument.api.input.TilleggsopplysningInput
 import no.nav.klage.dokument.api.mapper.DokumentEnhetInputMapper
 import no.nav.klage.dokument.api.mapper.DokumentEnhetMapper
 import no.nav.klage.dokument.api.view.DokumentEnhetView
@@ -64,16 +61,16 @@ internal class DokumentEnhetControllerTest {
             )
         } returns ikkeDistribuertDokumentEnhetMedToBrevMottakere
 
-        val dokumentEnhetInput = DokumentEnhetInput(
+        val dokumentEnhetInput = GammelDokumentEnhetInput(
             brevMottakere = listOf(
-                BrevMottakerInput(
-                    partId = PartIdInput(type = "PERSON", value = "20022012345"),
+                GammelDokumentEnhetInput.GammelBrevMottakerInput(
+                    partId = GammelDokumentEnhetInput.GammelPartIdInput(type = "PERSON", value = "20022012345"),
                     navn = "Mottaker Person",
                     rolle = "HOVEDADRESSAT"
                 )
             ),
-            journalfoeringData = JournalfoeringDataInput(
-                sakenGjelder = PartIdInput(
+            journalfoeringData = GammelDokumentEnhetInput.GammelJournalfoeringDataInput(
+                sakenGjelder = GammelDokumentEnhetInput.GammelPartIdInput(
                     type = "PERSON",
                     value = "01011012345"
                 ),
@@ -106,4 +103,36 @@ internal class DokumentEnhetControllerTest {
         assertThat(dokumentEnhet).isNotNull
         assertThat(dokumentEnhet.id).isEqualTo(ikkeDistribuertDokumentEnhetMedToBrevMottakere.id.toString())
     }
+}
+
+data class GammelDokumentEnhetInput(
+    val brevMottakere: List<GammelBrevMottakerInput>,
+    val journalfoeringData: GammelJournalfoeringDataInput
+) {
+    data class GammelBrevmottakereInput(
+        val brevMottakere: List<GammelBrevMottakerInput>
+    )
+
+    data class GammelBrevMottakerInput(
+        val partId: GammelPartIdInput,
+        val navn: String?,
+        val rolle: String,
+    )
+
+    data class GammelJournalfoeringDataInput(
+        val sakenGjelder: GammelPartIdInput,
+        val tema: String,
+        val sakFagsakId: String?,
+        val sakFagsystem: String?,
+        val kildeReferanse: String,
+        val enhet: String,
+        val behandlingstema: String,
+        val tittel: String,
+        val brevKode: String,
+        val tilleggsopplysning: TilleggsopplysningInput?
+    )
+
+
+    data class GammelPartIdInput(val type: String, val value: String)
+
 }


### PR DESCRIPTION
Endret APIet så det aksepterer enten IDer for kodene eller navnene, i en overgangsfase. Endret den ene testen for å bekrefte at gamle kall fremdeles skal fungere