### PR TITLE
Prepare app for notat, journalfoering but no distribution.

### DIFF
--- a/src/main/kotlin/no/nav/klage/dokument/api/mapper/DokumentEnhetInputMapper.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/api/mapper/DokumentEnhetInputMapper.kt
@@ -2,10 +2,12 @@ package no.nav.klage.dokument.api.mapper
 
 
 import no.nav.klage.dokument.api.input.DokumentEnhetWithDokumentreferanserInput
+import no.nav.klage.dokument.clients.joark.JournalpostType
 import no.nav.klage.dokument.domain.dokument.*
 import no.nav.klage.dokument.exceptions.DokumentEnhetNotValidException
 import no.nav.klage.dokument.util.getLogger
 import no.nav.klage.dokument.util.getSecureLogger
+import no.nav.klage.kodeverk.DokumentType
 import no.nav.klage.kodeverk.Fagsystem
 import no.nav.klage.kodeverk.PartIdType
 import no.nav.klage.kodeverk.Tema
@@ -34,7 +36,10 @@ class DokumentEnhetInputMapper {
             throw DokumentEnhetNotValidException("Ulovlig input: ${iae.message}")
         }
 
-    fun mapJournalfoeringDataInput(input: DokumentEnhetWithDokumentreferanserInput.JournalfoeringDataInput): JournalfoeringData =
+    fun mapJournalfoeringDataInput(
+        input: DokumentEnhetWithDokumentreferanserInput.JournalfoeringDataInput,
+        dokumentType: DokumentType
+    ): JournalfoeringData =
         try {
             JournalfoeringData(
                 sakenGjelder = mapPartIdInput(input.sakenGjelder),
@@ -47,7 +52,8 @@ class DokumentEnhetInputMapper {
                 behandlingstema = input.behandlingstema,
                 tittel = input.tittel,
                 brevKode = input.brevKode,
-                tilleggsopplysning = input.tilleggsopplysning?.let { Tilleggsopplysning(it.key, it.value) }
+                tilleggsopplysning = input.tilleggsopplysning?.let { Tilleggsopplysning(it.key, it.value) },
+                journalpostType = if (dokumentType == DokumentType.NOTAT) JournalpostType.NOTAT else JournalpostType.UTGAAENDE,
             )
         } catch (iae: IllegalArgumentException) {
             logger.warn("Data fra klient er ikke gyldig", iae)

--- a/src/main/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapper.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapper.kt
@@ -49,7 +49,6 @@ class JoarkMapper {
 
         if (journalfoeringData.journalpostType == JournalpostType.UTGAAENDE) {
             journalpost.avsenderMottaker = createAvsenderMottager(brevMottaker)
-            journalpost.kanal = "NAV_NO"
         }
 
         return journalpost

--- a/src/main/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapper.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapper.kt
@@ -23,12 +23,11 @@ class JoarkMapper {
         hovedDokument: JournalfoeringService.MellomlagretDokument,
         vedleggDokumentList: List<JournalfoeringService.MellomlagretDokument> = emptyList(),
         brevMottaker: BrevMottaker
-    ): Journalpost =
-        Journalpost(
-            journalposttype = JournalpostType.UTGAAENDE,
+    ): Journalpost {
+        val journalpost = Journalpost(
+            journalposttype = journalfoeringData.journalpostType,
             tema = journalfoeringData.tema,
             behandlingstema = journalfoeringData.behandlingstema,
-            avsenderMottaker = createAvsenderMottager(brevMottaker),
             sak = createSak(journalfoeringData),
             tittel = journalfoeringData.tittel,
             journalfoerendeEnhet = journalfoeringData.enhet,
@@ -47,6 +46,14 @@ class JoarkMapper {
                 )
             } ?: emptyList()
         )
+
+        if (journalfoeringData.journalpostType == JournalpostType.UTGAAENDE) {
+            journalpost.avsenderMottaker = createAvsenderMottager(brevMottaker)
+            journalpost.kanal = "NAV_NO"
+        }
+
+        return journalpost
+    }
 
     private fun createAvsenderMottager(brevMottaker: BrevMottaker): AvsenderMottaker =
         AvsenderMottaker(

--- a/src/main/kotlin/no/nav/klage/dokument/clients/joark/Journalpost.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/clients/joark/Journalpost.kt
@@ -6,7 +6,6 @@ data class Journalpost(
     val journalposttype: JournalpostType? = null,
     val tema: Tema,
     val behandlingstema: String,
-    var kanal: String? = null,
     val tittel: String,
     var avsenderMottaker: AvsenderMottaker? = null,
     val journalfoerendeEnhet: String? = null,

--- a/src/main/kotlin/no/nav/klage/dokument/clients/joark/Journalpost.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/clients/joark/Journalpost.kt
@@ -6,10 +6,9 @@ data class Journalpost(
     val journalposttype: JournalpostType? = null,
     val tema: Tema,
     val behandlingstema: String,
-    //TODO: Er dette riktig?
-    val kanal: String = "NAV_NO",
+    var kanal: String? = null,
     val tittel: String,
-    val avsenderMottaker: AvsenderMottaker? = null,
+    var avsenderMottaker: AvsenderMottaker? = null,
     val journalfoerendeEnhet: String? = null,
     val eksternReferanseId: String? = null,
     val bruker: Bruker? = null,

--- a/src/main/kotlin/no/nav/klage/dokument/domain/dokument/DokumentEnhet.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/domain/dokument/DokumentEnhet.kt
@@ -3,6 +3,7 @@ package no.nav.klage.dokument.domain.dokument
 import jakarta.persistence.*
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Table
+import no.nav.klage.dokument.clients.joark.JournalpostType
 import no.nav.klage.kodeverk.DokumentType
 import org.hibernate.annotations.*
 import java.time.LocalDateTime
@@ -42,9 +43,10 @@ class DokumentEnhet(
     var avsluttet: LocalDateTime? = null,
     @Column(name = "modified")
     var modified: LocalDateTime = LocalDateTime.now(),
-    @Column(name = "should_be_distributed")
-    var shouldBeDistributed: Boolean = true
 ) {
+    fun shouldBeDistributed(): Boolean {
+        return journalfoeringData.journalpostType == JournalpostType.UTGAAENDE
+    }
 
     fun isAvsluttet() = avsluttet != null
 
@@ -56,7 +58,7 @@ class DokumentEnhet(
 
     //Trengs dette?
     fun isProcessedForAll(): Boolean {
-        return if (shouldBeDistributed) {
+        return if (shouldBeDistributed()) {
             isDistributedToAll()
         } else {
             isJournalfoertForAll()

--- a/src/main/kotlin/no/nav/klage/dokument/domain/dokument/JournalfoeringData.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/domain/dokument/JournalfoeringData.kt
@@ -1,6 +1,7 @@
 package no.nav.klage.dokument.domain.dokument
 
 import jakarta.persistence.*
+import no.nav.klage.dokument.clients.joark.JournalpostType
 import no.nav.klage.kodeverk.Fagsystem
 import no.nav.klage.kodeverk.Tema
 import java.util.*
@@ -44,5 +45,8 @@ class JournalfoeringData(
         ]
     )
     val tilleggsopplysning: Tilleggsopplysning?,
+    @Column(name = "journalposttype")
+    @Enumerated(EnumType.STRING)
+    var journalpostType: JournalpostType = JournalpostType.UTGAAENDE
 )
 

--- a/src/main/kotlin/no/nav/klage/dokument/service/DokumentEnhetService.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/service/DokumentEnhetService.kt
@@ -82,7 +82,7 @@ class DokumentEnhetService(
             }
         }
 
-        if (dokumentEnhet.shouldBeDistributed) {
+        if (dokumentEnhet.shouldBeDistributed()) {
             dokumentEnhet.brevMottakerDistribusjoner.forEach { brevMottakerDistribusjon ->
                 if (brevMottakerDistribusjon.dokdistReferanse == null) {
                     try {
@@ -129,7 +129,7 @@ class DokumentEnhetService(
             brevMottaker = brevMottakerDistribusjon.brevMottaker,
             hoveddokument = dokumentEnhet.hovedDokument!!,
             vedleggDokumentList = dokumentEnhet.vedlegg,
-            journalfoeringData = dokumentEnhet.journalfoeringData
+            journalfoeringData = dokumentEnhet.journalfoeringData,
         )
     }
 
@@ -159,7 +159,9 @@ class DokumentEnhetService(
         input: DokumentEnhetWithDokumentreferanserInput
     ): DokumentEnhet {
         logger.debug("Creating dokumentEnhet")
-        val journalfoeringData = dokumentEnhetInputMapper.mapJournalfoeringDataInput(input.journalfoeringData)
+        val dokumentType = DokumentType.of(input.dokumentTypeId)
+        val journalfoeringData =
+            dokumentEnhetInputMapper.mapJournalfoeringDataInput(input.journalfoeringData, dokumentType)
         val brevMottakere = dokumentEnhetInputMapper.mapBrevMottakereInput(input.brevMottakere)
         val hovedokument =
             dokumentEnhetInputMapper.mapDokumentInputToHoveddokument(input.dokumentreferanser.hoveddokument)
@@ -167,7 +169,6 @@ class DokumentEnhetService(
             dokumentEnhetInputMapper.mapDokumentInputToVedlegg(it)
         } ?: emptyList()
         val brevMottakerDistribusjoner = createBrevMottakerDistribusjoner(brevMottakere, hovedokument.id)
-        val dokumentType = DokumentType.of(input.dokumentTypeId)
         return dokumentEnhetRepository.save(
             DokumentEnhet(
                 journalfoeringData = journalfoeringData,
@@ -176,7 +177,6 @@ class DokumentEnhetService(
                 hovedDokument = hovedokument,
                 vedlegg = vedlegg,
                 dokumentType = dokumentType,
-                shouldBeDistributed = dokumentType != DokumentType.NOTAT
             )
         )
     }

--- a/src/main/resources/db/migration/V11__Add_journalposttype_to_journalfoeringdata.sql
+++ b/src/main/resources/db/migration/V11__Add_journalposttype_to_journalfoeringdata.sql
@@ -1,0 +1,6 @@
+ALTER TABLE document.journalfoeringdata
+    ADD COLUMN IF NOT EXISTS journalposttype TEXT;
+
+ALTER TABLE document.dokumentenhet
+DROP
+COLUMN IF EXISTS should_be_distributed;

--- a/src/test/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapperTest.kt
+++ b/src/test/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapperTest.kt
@@ -113,7 +113,6 @@ internal class JoarkMapperTest {
         journalposttype = JournalpostType.UTGAAENDE,
         tema = TEMA,
         behandlingstema = BEHANDLINGSTEMA,
-        kanal = "NAV_NO",
         tittel = TITTEL,
         avsenderMottaker = AvsenderMottaker(
             id = FNR,
@@ -143,7 +142,6 @@ internal class JoarkMapperTest {
         journalposttype = JournalpostType.UTGAAENDE,
         tema = TEMA,
         behandlingstema = BEHANDLINGSTEMA,
-        kanal = "NAV_NO",
         tittel = TITTEL,
         avsenderMottaker = AvsenderMottaker(
             id = FNR,

--- a/src/test/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapperTest.kt
+++ b/src/test/kotlin/no/nav/klage/dokument/clients/joark/JoarkMapperTest.kt
@@ -54,7 +54,7 @@ internal class JoarkMapperTest {
         behandlingstema = BEHANDLINGSTEMA,
         tittel = TITTEL,
         brevKode = BREVKODE,
-        tilleggsopplysning = null
+        tilleggsopplysning = null,
     )
 
     private val opplastetHovedDokument = OpplastetHoveddokument(
@@ -113,6 +113,7 @@ internal class JoarkMapperTest {
         journalposttype = JournalpostType.UTGAAENDE,
         tema = TEMA,
         behandlingstema = BEHANDLINGSTEMA,
+        kanal = "NAV_NO",
         tittel = TITTEL,
         avsenderMottaker = AvsenderMottaker(
             id = FNR,
@@ -142,6 +143,7 @@ internal class JoarkMapperTest {
         journalposttype = JournalpostType.UTGAAENDE,
         tema = TEMA,
         behandlingstema = BEHANDLINGSTEMA,
+        kanal = "NAV_NO",
         tittel = TITTEL,
         avsenderMottaker = AvsenderMottaker(
             id = FNR,

--- a/src/test/kotlin/no/nav/klage/dokument/repositories/DokumentEnhetRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/klage/dokument/repositories/DokumentEnhetRepositoryTest.kt
@@ -75,7 +75,7 @@ class DokumentEnhetRepositoryTest {
     fun `update DokumentEnhet works as expected`() {
         dokumentEnhetRepository.save(dokumentEnhet)
         val firstDokumentEnhet = dokumentEnhetRepository.getReferenceById(dokumentEnhet.id)
-        firstDokumentEnhet.shouldBeDistributed = false
+        firstDokumentEnhet.modified = LocalDateTime.now()
         val secondDokumentEnhet = dokumentEnhetRepository.getReferenceById(dokumentEnhet.id)
 
         assertThat(firstDokumentEnhet).isEqualTo(secondDokumentEnhet)

--- a/src/test/kotlin/no/nav/klage/dokument/service/DokumentEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/dokument/service/DokumentEnhetServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.klage.dokument.api.mapper.DokumentEnhetInputMapper
+import no.nav.klage.dokument.clients.joark.JournalpostType
 import no.nav.klage.dokument.domain.dokument.*
 import no.nav.klage.dokument.repositories.BrevMottakerDistribusjonRepository
 import no.nav.klage.dokument.repositories.DokumentEnhetRepository
@@ -75,7 +76,8 @@ internal class DokumentEnhetServiceTest {
             behandlingstema = "behandlingstema",
             tittel = "Tittel",
             brevKode = "brevKode",
-            tilleggsopplysning = Tilleggsopplysning("key", "value")
+            tilleggsopplysning = Tilleggsopplysning("key", "value"),
+            journalpostType = JournalpostType.UTGAAENDE
         ),
         brevMottakere = setOf(brevMottaker1, brevMottaker2),
         brevMottakerDistribusjoner = setOf(brevMottakerDistribusjon1, brevMottakerDistribusjon2),
@@ -229,7 +231,7 @@ internal class DokumentEnhetServiceTest {
 
     fun ikkeDistribuertDokumentEnhetMedVedleggOgToBrevMottakereNotForDistribution(): DokumentEnhet {
         val dokumentEnhet = baseDokumentEnhet
-        dokumentEnhet.shouldBeDistributed = false
+        dokumentEnhet.journalfoeringData.journalpostType = JournalpostType.NOTAT
         return dokumentEnhet
     }
 


### PR DESCRIPTION
Add journalposttype to JournalfoeringData, based on dokumenttype. DokumentEnhet.shouldBeDistributed is now a function based on journalposttype in journalfoeringdata.